### PR TITLE
Remove magic numbers, fix crash bug while rectifying program_arguments

### DIFF
--- a/manifest.c
+++ b/manifest.c
@@ -547,7 +547,7 @@ static ucl_object_t* job_manifest_get_object(unsigned char *buf, size_t buf_size
 	struct ucl_parser *parser = NULL;
 	ucl_object_t *obj = NULL;
 
-	parser = ucl_parser_new(0);
+	parser = ucl_parser_new(UCL_PARSER_DEFAULT);
 
 	if (!parser)
 		return NULL;

--- a/manifest.c
+++ b/manifest.c
@@ -138,7 +138,7 @@ static int job_manifest_parse_cvec(cvec_t *dst, const ucl_object_t *obj)
 	if (!vector)
 	{
 		log_error("unable to allocate vector");
-		return -1;
+		return JOB_MANIFEST_MEMORY_FAILURE;
 	}
 
 	while ((tmp = ucl_iterate_object (obj, &it, true)))
@@ -147,7 +147,7 @@ static int job_manifest_parse_cvec(cvec_t *dst, const ucl_object_t *obj)
 		{
 			log_error("unexpected object type while parsing environment variables");
 			cvec_free(vector);
-			return -1;
+			return JOB_MANIFEST_MEMORY_FAILURE;
 		}
 
 		log_debug("adding array element: %s", ucl_object_tostring(tmp));
@@ -158,87 +158,87 @@ static int job_manifest_parse_cvec(cvec_t *dst, const ucl_object_t *obj)
 		cvec_free(*dst);
 
 	*dst = vector;
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_label(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->label = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->label = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_user_name(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->user_name = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->user_name = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_group_name(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->group_name = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->group_name = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_program(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->program = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->program = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_jail_name(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->jail_name = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->jail_name = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_working_directory(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->working_directory = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->working_directory = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_root_directory(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->root_directory = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->root_directory = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_standard_in_path(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->stdin_path = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->stdin_path = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_standard_out_path(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->stdout_path = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->stdout_path = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_standard_error_path(job_manifest_t manifest, const ucl_object_t *obj)
 {
-	return (manifest->stderr_path = strdup(ucl_object_tostring(obj))) ? 0 : -1;
+	return (manifest->stderr_path = strdup(ucl_object_tostring(obj))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_parse_enable_globbing(job_manifest_t manifest, const ucl_object_t *obj)
 {
 	manifest->enable_globbing = ucl_object_toboolean(obj);
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_run_at_load(job_manifest_t manifest, const ucl_object_t *obj)
 {
 	manifest->run_at_load = ucl_object_toboolean(obj);
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_start_on_mount(job_manifest_t manifest, const ucl_object_t *obj)
 {
 	manifest->start_on_mount = ucl_object_toboolean(obj);
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_init_groups(job_manifest_t manifest, const ucl_object_t *obj)
 {
 	manifest->init_groups = ucl_object_toboolean(obj);
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_abandon_process_group(job_manifest_t manifest, const ucl_object_t *obj)
 {
 	manifest->abandon_process_group = ucl_object_toboolean(obj);
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_environment_variables(job_manifest_t manifest, const ucl_object_t *obj)
@@ -251,7 +251,7 @@ static int job_manifest_parse_environment_variables(job_manifest_t manifest, con
 	if (!vector)
 	{
 		log_error("failed to allocate vector");
-		return -1;
+		return JOB_MANIFEST_MEMORY_FAILURE;
 	}
 
 	while ((tmp = ucl_iterate_object (obj, &it, true)))
@@ -260,7 +260,7 @@ static int job_manifest_parse_environment_variables(job_manifest_t manifest, con
 		{
 			log_error("unexpected object type while parsing environment variables");
 			cvec_free(vector);
-			return -1;
+			return JOB_MANIFEST_PARSE_FAILURE;
 		}
 
 		log_debug("adding environment variable: %s=%s", ucl_object_key(tmp), ucl_object_tostring(tmp));
@@ -272,14 +272,14 @@ static int job_manifest_parse_environment_variables(job_manifest_t manifest, con
 	{
 		log_error("parsed an odd number of environment variables");
 		cvec_free(vector);
-		return -1;
+		return JOB_MANIFEST_PARSE_FAILURE;
 	}
 
 	if (manifest->environment_variables)
 		cvec_free(manifest->environment_variables);
 
 	manifest->environment_variables = vector;
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_program_arguments(job_manifest_t manifest, const ucl_object_t *obj)
@@ -300,7 +300,7 @@ static int job_manifest_parse_queue_directories(job_manifest_t manifest, const u
 static int job_manifest_parse_start_interval(job_manifest_t manifest, const ucl_object_t *obj)
 {
 	manifest->start_interval = ucl_object_toint(obj);
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_sockets(job_manifest_t manifest, const ucl_object_t *obj)
@@ -323,31 +323,31 @@ static int job_manifest_parse_sockets(job_manifest_t manifest, const ucl_object_
 				{
 					log_error("object type mismatch while parsing sockets");
 					job_manifest_socket_free(socket);
-					return -1;
+					return JOB_MANIFEST_PARSE_FAILURE;
 				}
 
 				if (socket_parser->parser(socket, cur))
 				{
 					log_error("failed to parse socket child");
 					job_manifest_socket_free(socket);
-					return -1;
+					return JOB_MANIFEST_PARSE_FAILURE;
 				}
 			}
 		}
 
 		SLIST_INSERT_HEAD(&manifest->sockets, socket, entry);
 	}
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 static int job_manifest_parse_sock_service_name(struct job_manifest_socket *socket, const ucl_object_t *object)
 {
-	return (socket->sock_service_name = strdup(ucl_object_tostring(object))) ? 0 : -1;
+	return (socket->sock_service_name = strdup(ucl_object_tostring(object))) ? JOB_MANIFEST_SUCCESS : JOB_MANIFEST_PARSE_FAILURE;
 }
 
 static int job_manifest_rectify(job_manifest_t job_manifest)
 {
-	int i, retval = -1;
+	int i, retval = JOB_MANIFEST_FAILURE;
 	cvec_t new_argv = NULL;
 	uid_t uid;
 	struct passwd *pwent;
@@ -372,12 +372,12 @@ static int job_manifest_rectify(job_manifest_t job_manifest)
 			free(job_manifest->user_name);
 
 		if ((pwent = getpwuid(uid)) == NULL)
-			return -1;
+			return JOB_MANIFEST_FAILURE;
 
 		job_manifest->user_name = strdup(pwent->pw_name);
 
 		if ((grent = getgrgid(pwent->pw_gid)) == NULL)
-			return -1;
+			return JOB_MANIFEST_FAILURE;
 
 		if (job_manifest->group_name)
 			free(job_manifest->group_name);
@@ -405,7 +405,7 @@ static int job_manifest_rectify(job_manifest_t job_manifest)
 
 	job_manifest->init_groups = true;
 
-	retval = 0;
+	retval = JOB_MANIFEST_SUCCESS;
 
 out:
 	free(new_argv);
@@ -416,28 +416,28 @@ static int job_manifest_validate(job_manifest_t job_manifest)
 {
 	if (!job_manifest->label) {
 		log_error("job does not have a label");
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 	}
 
 	/* Require Program or ProgramArguments */
 	if (!job_manifest->program && cvec_length(job_manifest->program_arguments) == 0) {
 		log_error("job does not set Program or ProgramArguments");
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 	}
 
 	if (!job_manifest->user_name)
 	{
 		log_error("job %s does not set `user_name'", job_manifest->label);
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 	}
 
 	if (!job_manifest->group_name)
 	{
 		log_error("job %s does not set `group_name'", job_manifest->label);
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 	}
 
-	return 0;
+	return JOB_MANIFEST_SUCCESS;
 }
 
 job_manifest_t job_manifest_new(void)
@@ -447,7 +447,7 @@ job_manifest_t job_manifest_new(void)
 	job_manifest = calloc(1, sizeof(*job_manifest));
 
 	if (!job_manifest)
-		return (NULL);
+		return NULL;
 
 	job_manifest->exit_timeout = DEFAULT_EXIT_TIMEOUT;
 	job_manifest->throttle_interval = DEFAULT_THROTTLE_INTERVAL;
@@ -504,14 +504,14 @@ static unsigned char* job_manifest_prepare_buf_for_file(const char *filename, si
 
 static int job_manifest_read_from_file(unsigned char *buf, size_t buf_size, const char *filename)
 {
-	int rc = 0;
+	int rc = JOB_MANIFEST_SUCCESS;
 	FILE *f = NULL;
 
 	if (!(f = fopen(filename, "r")))
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 
 	if (fread(buf, 1, buf_size - 1, f) != buf_size - 1)
-		rc = -1;
+		rc = JOB_MANIFEST_FAILURE;
 
 	buf[buf_size] = 0;
 
@@ -523,13 +523,13 @@ int job_manifest_read(job_manifest_t job_manifest, const char *filename)
 {
 	unsigned char *buf = NULL;
 	size_t buf_size;
-	int rc = 0;
+	int rc = JOB_MANIFEST_SUCCESS;
 
 	if (!(buf = job_manifest_prepare_buf_for_file(filename, &buf_size)))
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 
 	if (job_manifest_read_from_file(buf, buf_size, filename))
-		return -1;
+		rc = JOB_MANIFEST_FAILURE;
 
 	if (!rc)
 		rc = job_manifest_parse(job_manifest, buf, buf_size);
@@ -563,19 +563,19 @@ static ucl_object_t* job_manifest_get_object(unsigned char *buf, size_t buf_size
 
 static int job_manifest_parse_child(job_manifest_t job_manifest, const ucl_object_t *tmp)
 {
-	int rc = 0;
+	int rc = JOB_MANIFEST_SUCCESS;
 	log_debug("parsing key `%s'", ucl_object_key(tmp));
 	for (const job_manifest_item_parser_t *item_parser = manifest_parser_map; item_parser->key != NULL; item_parser++) {
 		if (!strcmp(item_parser->key, ucl_object_key(tmp))) {
 			if (!job_manifest_object_is_type(tmp, item_parser->object_type)) {
 				log_error("failed while validating key `%s' with value: `%s'", ucl_object_key(tmp), ucl_object_tostring_forced(tmp));
-				rc = -1;
+				rc = JOB_MANIFEST_PARSE_FAILURE;
 			}
 			else {
 				log_debug("parsing value `%s'", ucl_object_tostring_forced(tmp));
 				if (item_parser->parser(job_manifest, tmp)) {
 					log_error("failed while parsing key `%s' with value: `%s'", ucl_object_key(tmp), ucl_object_tostring_forced(tmp));
-					rc = -1;
+					rc = JOB_MANIFEST_PARSE_FAILURE;
 				}
 			}
 			break;
@@ -586,13 +586,13 @@ static int job_manifest_parse_child(job_manifest_t job_manifest, const ucl_objec
 
 static int job_manifest_parse(job_manifest_t job_manifest, unsigned char *buf, size_t buf_size)
 {
-	int rc = 0;
+	int rc = JOB_MANIFEST_SUCCESS;
 	const ucl_object_t *tmp = NULL;
 	ucl_object_iter_t it = NULL;
 	ucl_object_t *obj;
 
 	if (!(obj = job_manifest_get_object(buf, buf_size)))
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 
 	while ((tmp = ucl_iterate_object (obj, &it, true)))
 		if ((rc = job_manifest_parse_child(job_manifest, tmp)))
@@ -605,12 +605,12 @@ static int job_manifest_parse(job_manifest_t job_manifest, unsigned char *buf, s
 
 	if (job_manifest_rectify(job_manifest)) {
 		log_error("unable to rectify job %s", job_manifest->label ? job_manifest->label : "unknown");
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 	}
 
 	if (job_manifest_validate(job_manifest)) {
 		log_error("job %s failed validation", job_manifest->label ? job_manifest->label : "unknown");
-		return -1;
+		return JOB_MANIFEST_FAILURE;
 	}
 
 	return rc;

--- a/manifest.h
+++ b/manifest.h
@@ -66,6 +66,13 @@ typedef struct job_manifest {
 	int32_t refcount;
 } *job_manifest_t;
 
+typedef enum job_manifest_return_code {
+	JOB_MANIFEST_PARSE_FAILURE = -3,
+	JOB_MANIFEST_MEMORY_FAILURE = -2,
+	JOB_MANIFEST_FAILURE = -1,
+	JOB_MANIFEST_SUCCESS = 0,
+} job_manifest_return_code_t;
+
 job_manifest_t job_manifest_new(void);
 void job_manifest_free(job_manifest_t job_manifest);
 int job_manifest_read(job_manifest_t job_manifest, const char *filename);


### PR DESCRIPTION
- Added a JOB_MANIFEST_RETURN_CODE enum to remove magic numbers from manifest.c
- Fixed crash bug when rectifying program_arguments when program_arguments is NULL
