### PR TITLE
fixed Linux build

### DIFF
--- a/src/libjob/libjob.cpp
+++ b/src/libjob/libjob.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <string>
 #include <cstdlib>
+#include <system_error>
 
 extern "C" {
 	#include <sys/stat.h>


### PR DESCRIPTION
Hi there,

i fixed the includes in libjop.cpp. The missing "system_error" yielded errors like

```
libjob.cpp:108:41: error: no member named 'system_category' in namespace 'std'
                                throw std::system_error(errno, std::system_category());
```

when compiling on a Linux box.
Cheers,
tpltnt
